### PR TITLE
fix perimeter calculation

### DIFF
--- a/areacalc/area.rs
+++ b/areacalc/area.rs
@@ -9,7 +9,7 @@ fn Square(a: u32, b: u32) -> bool {
 }
 
 fn CalcPandA(a: u32, b: u32, Sqaureness: bool) { // parameters are the four sides
-	let Perimiter = a + b; // calculate perimiter
+	let Perimiter = 2 * (a + b); // calculate perimiter
 	let Area = a * b; // calculate area
 	if Sqaureness {  // print it
 		println!("Square\nPerimiter: {Perimiter}\nArea: {Area}");


### PR DESCRIPTION
in areacalc/area.rs, your code for calculating perimeter was to add side a and side b together.  On a rectangle, side a and side b both have to be doubled and added together for the full perimeter to be calculated.  :3 

I don't know why this needs to be a PR, but it bugged me when I looked at it, so there ya go.